### PR TITLE
fix message receive and add appid

### DIFF
--- a/Photino.Blazor/AssemblyAppIdAttribute.cs
+++ b/Photino.Blazor/AssemblyAppIdAttribute.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Photino.Blazor;
+
+public class AssemblyAppIdAttribute : Attribute
+{
+    public string AppId { get; set; }
+
+    public AssemblyAppIdAttribute(string appid)
+    {
+        AppId = appid;
+    }
+}

--- a/Photino.Blazor/Photino.Blazor.csproj
+++ b/Photino.Blazor/Photino.Blazor.csproj
@@ -34,13 +34,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="6.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Microsoft.JSInterop" Version="6.0.1" />
+    <PackageReference Include="Microsoft.JSInterop" Version="6.0.5" />
     <PackageReference Include="Photino.NET" Version="2.1.11" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>

--- a/Photino.Blazor/PhotinoBlazorAppBuilder.cs
+++ b/Photino.Blazor/PhotinoBlazorAppBuilder.cs
@@ -42,7 +42,7 @@ namespace Photino.Blazor
         public PhotinoBlazorApp Build(Action<IServiceProvider> serviceProviderOptions = null)
         {
             var sp = Services.BuildServiceProvider();
-            var app = sp.GetService<PhotinoBlazorApp>();
+            var app = sp.GetRequiredService<PhotinoBlazorApp>();
 
             serviceProviderOptions?.Invoke(sp);
 

--- a/Photino.Blazor/PhotinoWebViewManager.cs
+++ b/Photino.Blazor/PhotinoWebViewManager.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -28,9 +28,11 @@ namespace Photino.Blazor
             : "app";
 
         public static readonly string AppBaseUri
-            = $"{BlazorAppScheme}://0.0.0.0/";
+            = $"{BlazorAppScheme}://{Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyAppIdAttribute>()?.AppId}/";
 
-        public PhotinoWebViewManager(PhotinoWindow window, IServiceProvider provider, Dispatcher dispatcher, Uri appBaseUri, IFileProvider fileProvider, JSComponentConfigurationStore jsComponents, string hostPageRelativePath)
+        public PhotinoWebViewManager(PhotinoWindow window, IServiceProvider provider, Dispatcher dispatcher,
+            Uri appBaseUri, IFileProvider fileProvider, JSComponentConfigurationStore jsComponents,
+            string hostPageRelativePath)
             : base(provider, dispatcher, appBaseUri, fileProvider, jsComponents, hostPageRelativePath)
         {
             _window = window ?? throw new ArgumentNullException(nameof(window));
@@ -61,7 +63,8 @@ namespace Photino.Blazor
             var hasFileExtension = localPath.LastIndexOf('.') > localPath.LastIndexOf('/');
 
             if (url.StartsWith(AppBaseUri, StringComparison.Ordinal)
-                && TryGetResponseContent(url, !hasFileExtension, out var statusCode, out var statusMessage, out var content, out var headers))
+                && TryGetResponseContent(url, !hasFileExtension, out var statusCode, out var statusMessage,
+                    out var content, out var headers))
             {
                 headers.TryGetValue("Content-Type", out contentType);
                 return content;
@@ -80,7 +83,8 @@ namespace Photino.Blazor
 
         protected override void SendMessage(string message)
         {
-            Task.Run(() => Dispatcher.InvokeAsync(() => _window.SendWebMessage(message)));
+            Task.Run(() => { Dispatcher.InvokeAsync(() => _window.SendWebMessage(message)); })
+                .Wait(TimeSpan.FromSeconds(2));
         }
     }
 }

--- a/Photino.Blazor/PhotinoWebViewManager.cs
+++ b/Photino.Blazor/PhotinoWebViewManager.cs
@@ -84,7 +84,7 @@ namespace Photino.Blazor
         protected override void SendMessage(string message)
         {
             Task.Run(() => { Dispatcher.InvokeAsync(() => _window.SendWebMessage(message)); })
-                .Wait(TimeSpan.FromSeconds(2));
+                .Wait();
         }
     }
 }


### PR DESCRIPTION
Made a little optimization to #40 to wait for asynchronous operations. SendMessage should be a synchronous call. When clicking different NavLinks too quickly, using Task for asynchronous processing will trigger this problem.

Added appid attribute to resolve #53.
Add `[assembly: AssemblyAppId("your app id")]` in `Properties/AssemblyInfo.cs` of the application entry project