### PR TITLE
Refactor to increase reliance on dependency injection

### DIFF
--- a/Photino.Blazor/PhotinoBlazorApp.cs
+++ b/Photino.Blazor/PhotinoBlazorApp.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using PhotinoNET;
 using System;
 using System.IO;
@@ -6,28 +7,23 @@ namespace Photino.Blazor
 {
     public class PhotinoBlazorApp
     {
-        public PhotinoBlazorApp(IServiceProvider services, BlazorWindowRootComponents rootComponents, PhotinoWindow mainWindow, PhotinoWebViewManager windowManager, RootComponentList components)
-        {
-            Services = services;
-            RootComponents = rootComponents;
-            MainWindow = mainWindow;
-            WindowManager = windowManager;
-
-            Initialize(components);
-        }
-
         /// <summary>
         /// Gets configuration for the service provider.
         /// </summary>
-        public IServiceProvider Services { get; }
+        public IServiceProvider Services { get; private set; }
 
         /// <summary>
         /// Gets configuration for the root components in the window.
         /// </summary>
-        public BlazorWindowRootComponents RootComponents { get; }
+        public BlazorWindowRootComponents RootComponents { get; private set; }
 
-        private void Initialize(RootComponentList rootComponents)
+        internal void Initialize(IServiceProvider services, RootComponentList rootComponents)
         {
+            Services = services;
+            RootComponents = Services.GetService<BlazorWindowRootComponents>();
+            MainWindow = Services.GetService<PhotinoWindow>();
+            WindowManager = Services.GetService<PhotinoWebViewManager>();
+
             MainWindow
                 .SetTitle("Photino.Blazor App")
                 .SetUseOsDefaultLocation(false)
@@ -44,9 +40,9 @@ namespace Photino.Blazor
             }
         }
 
-        public PhotinoWindow MainWindow { get; }
+        public PhotinoWindow MainWindow { get; private set; }
 
-        public PhotinoWebViewManager WindowManager { get; }
+        public PhotinoWebViewManager WindowManager { get; private set; }
 
         public void Run()
         {

--- a/Photino.Blazor/PhotinoBlazorAppBuilder.cs
+++ b/Photino.Blazor/PhotinoBlazorAppBuilder.cs
@@ -1,10 +1,8 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Net.Http;
 
 namespace Photino.Blazor
 {
@@ -22,10 +20,7 @@ namespace Photino.Blazor
             // here so that it shows up this way in the project templates.
             // var jsRuntime = DefaultWebAssemblyJSRuntime.Instance;
             var builder = new PhotinoBlazorAppBuilder();
-            builder.Services
-                .AddScoped(sp => new HttpClient(new PhotinoHttpHandler(sp.GetService<PhotinoBlazorApp>())) { BaseAddress = new Uri(PhotinoWebViewManager.AppBaseUri) })
-                .AddSingleton<PhotinoBlazorApp>()
-                .AddBlazorWebView();
+            builder.Services.AddBlazorDesktop();
 
             // Right now we don't have conventions or behaviors that are specific to this method
             // however, making this the default for the template allows us to add things like that
@@ -38,22 +33,23 @@ namespace Photino.Blazor
 
         public IServiceCollection Services { get; }
 
-
         public PhotinoBlazorApp Build(Action<IServiceProvider> serviceProviderOptions = null)
         {
+            // register root components with DI container
+            Services.AddSingleton(RootComponents);
+
             var sp = Services.BuildServiceProvider();
             var app = sp.GetRequiredService<PhotinoBlazorApp>();
 
             serviceProviderOptions?.Invoke(sp);
 
-            app.Initialize(sp, RootComponents);
             return app;
         }
     }
 
     public class RootComponentList : IEnumerable<(Type, string)>
     {
-        private List<(Type componentType, string domElementSelector)> components = new List<(Type componentType, string domElementSelector)>();
+        private readonly List<(Type componentType, string domElementSelector)> components = new List<(Type componentType, string domElementSelector)>();
 
         public void Add<TComponent>(string selector) where TComponent : IComponent
         {

--- a/Photino.Blazor/PhotinoBlazorAppBuilder.cs
+++ b/Photino.Blazor/PhotinoBlazorAppBuilder.cs
@@ -36,13 +36,14 @@ namespace Photino.Blazor
         public PhotinoBlazorApp Build(Action<IServiceProvider> serviceProviderOptions = null)
         {
             // register root components with DI container
-            Services.AddSingleton(RootComponents);
+            // Services.AddSingleton(RootComponents);
 
             var sp = Services.BuildServiceProvider();
             var app = sp.GetRequiredService<PhotinoBlazorApp>();
 
             serviceProviderOptions?.Invoke(sp);
 
+            app.Initialize(sp, RootComponents);
             return app;
         }
     }

--- a/Photino.Blazor/PhotinoBlazorAppConfiguration.cs
+++ b/Photino.Blazor/PhotinoBlazorAppConfiguration.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Photino.Blazor
+{
+    public class PhotinoBlazorAppConfiguration
+    {
+        public Uri AppBaseUri { get; set; }
+
+        public string HostPage { get; set; }
+    }
+}

--- a/Photino.Blazor/PhotinoDispatcher.cs
+++ b/Photino.Blazor/PhotinoDispatcher.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using PhotinoNET;
 
 namespace Photino.Blazor
 {
@@ -13,13 +12,10 @@ namespace Photino.Blazor
     {
         private readonly PhotinoSynchronizationContext _context;
 
-        public PhotinoDispatcher(PhotinoWindow window)
+        public PhotinoDispatcher(PhotinoSynchronizationContext context)
         {
-            _context = new PhotinoSynchronizationContext(window);
-            _context.UnhandledException += (sender, e) =>
-            {
-                OnUnhandledException(e);
-            };
+            _context = context;
+            _context.UnhandledException += (sender, e) => OnUnhandledException(e);
         }
 
         public override bool CheckAccess() => SynchronizationContext.Current == _context;

--- a/Photino.Blazor/PhotinoHttpHandler.cs
+++ b/Photino.Blazor/PhotinoHttpHandler.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,7 +9,7 @@ namespace Photino.Blazor
 {
     public class PhotinoHttpHandler : DelegatingHandler
     {
-        private PhotinoBlazorApp app;
+        private readonly PhotinoBlazorApp app;
 
         //use this constructor if a handler is registered in DI to inject dependencies
         public PhotinoHttpHandler(PhotinoBlazorApp app) : this(app, null)

--- a/Photino.Blazor/PhotinoWebViewManager.cs
+++ b/Photino.Blazor/PhotinoWebViewManager.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebView;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
 using PhotinoNET;
 using System;
 using System.IO;
@@ -31,9 +32,8 @@ namespace Photino.Blazor
         public static readonly string AppBaseUri = $"{BlazorAppScheme}://localhost/";
 
         public PhotinoWebViewManager(PhotinoWindow window, IServiceProvider provider, Dispatcher dispatcher,
-            Uri appBaseUri, IFileProvider fileProvider, JSComponentConfigurationStore jsComponents,
-            string hostPageRelativePath)
-            : base(provider, dispatcher, appBaseUri, fileProvider, jsComponents, hostPageRelativePath)
+            IFileProvider fileProvider, JSComponentConfigurationStore jsComponents, IOptions<PhotinoBlazorAppConfiguration> config)
+            : base(provider, dispatcher, config.Value.AppBaseUri, fileProvider, jsComponents, config.Value.HostPage)
         {
             _window = window ?? throw new ArgumentNullException(nameof(window));
 

--- a/Photino.Blazor/ServiceCollectionExtensions.cs
+++ b/Photino.Blazor/ServiceCollectionExtensions.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using PhotinoNET;
+
+namespace Photino.Blazor
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddBlazorDesktop(this IServiceCollection services)
+        {
+            services
+                .AddOptions<PhotinoBlazorAppConfiguration>()
+                .Configure(opts =>
+                {
+                    opts.AppBaseUri = new Uri(PhotinoWebViewManager.AppBaseUri);
+                    opts.HostPage = "index.html";
+                });
+
+            return services
+                .AddScoped(sp =>
+                {
+                    var handler = sp.GetService<PhotinoHttpHandler>();
+                    return new HttpClient(handler) { BaseAddress = new Uri(PhotinoWebViewManager.AppBaseUri) };
+                })
+                .AddSingleton(sp =>
+                {
+                    var manager = sp.GetService<PhotinoWebViewManager>();
+                    var store = sp.GetService<JSComponentConfigurationStore>();
+
+                    return new BlazorWindowRootComponents(manager, store);
+                })
+                .AddSingleton<Dispatcher, PhotinoDispatcher>()
+                .AddSingleton<IFileProvider>(_ =>
+                {
+                    var root = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "wwwroot");
+                    return new PhysicalFileProvider(root);
+                })
+                .AddSingleton<JSComponentConfigurationStore>()
+                .AddSingleton<PhotinoBlazorApp>()
+                .AddSingleton<PhotinoHttpHandler>()
+                .AddSingleton<PhotinoSynchronizationContext>()
+                .AddSingleton<PhotinoWebViewManager>()
+                .AddSingleton(new PhotinoWindow())
+                .AddBlazorWebView();
+        }
+    }
+}


### PR DESCRIPTION
Did some refactoring to increase the reliance on dependency injection. I changed a few constructors in order to be able to inject dependencies into the classes that required them.  

There are no changes for the end user and this should be seamless.

However, this does opens up possibilities where we could configure Photino.Blazor's behavior with extension methods. For example, one could add wwwroot as an EmbeddedResource and have the file embedded in the dll instead of outputting them to the bin folder.

Please let me know if there's anything.

Cheers! 