### PR TITLE
[PhotinoWebViewManager] fix Dispatcher SendMessage

### DIFF
--- a/Photino.Blazor/PhotinoWebViewManager.cs
+++ b/Photino.Blazor/PhotinoWebViewManager.cs
@@ -80,7 +80,7 @@ namespace Photino.Blazor
 
         protected override void SendMessage(string message)
         {
-            Task.Run(() => Dispatcher.InvokeAsync(() => _window.SendWebMessage(message)));
+            _ = Dispatcher.InvokeAsync(() => _window.SendWebMessage(message));
         }
     }
 }

--- a/Photino.Blazor/PhotinoWebViewManager.cs
+++ b/Photino.Blazor/PhotinoWebViewManager.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -18,6 +19,7 @@ namespace Photino.Blazor
     public class PhotinoWebViewManager : WebViewManager
     {
         private readonly PhotinoWindow _window;
+        private readonly Channel<string> _channel;
 
         // On Windows, we can't use a custom scheme to host the initial HTML,
         // because webview2 won't let you do top-level navigation to such a URL.
@@ -51,6 +53,10 @@ namespace Photino.Blazor
                     MessageReceived(messageOriginUrl, (string)message!);
                 }, message, CancellationToken.None, TaskCreationOptions.DenyChildAttach, sts);
             };
+
+            //Create channel and start reader
+            _channel = Channel.CreateUnbounded<string>(new UnboundedChannelOptions() { SingleReader = true, SingleWriter = false, AllowSynchronousContinuations = false });
+            Task.Run(messagePump);
         }
 
         public Stream HandleWebRequest(object sender, string schema, string url, out string contentType)
@@ -80,7 +86,31 @@ namespace Photino.Blazor
 
         protected override void SendMessage(string message)
         {
-            _ = Dispatcher.InvokeAsync(() => _window.SendWebMessage(message));
+            while (!_channel.Writer.TryWrite(message))
+                Thread.Sleep(200);
+        }
+
+        async Task messagePump()
+        {
+            var reader = _channel.Reader;
+            try
+            {
+                while (true)
+                {
+                    var message = await reader.ReadAsync();
+                    _window.SendWebMessage(message);
+                }
+            }
+            catch (ChannelClosedException) { }
+        }
+
+        protected override ValueTask DisposeAsyncCore()
+        {
+            //complete channel
+            try { _channel.Writer.Complete(); } catch { }
+
+            //continue disposing
+            return base.DisposeAsyncCore();
         }
     }
 }


### PR DESCRIPTION
This is a fix for issue #40

Instead of using `Task.Run(...).Wait()` ( as in PR #54 )  which causes the app to freeze in my case, i call the dispatcher to make sure the call is enqueued and then throw away the dispatcher's invoke-completion task.
