### PR TITLE
Add custom file provider as input

### DIFF
--- a/Photino.Blazor/PhotinoBlazorApp.cs
+++ b/Photino.Blazor/PhotinoBlazorApp.cs
@@ -18,7 +18,7 @@ namespace Photino.Blazor
         /// </summary>
         public BlazorWindowRootComponents RootComponents { get; private set; }
 
-        internal void Initialize(IServiceProvider services, RootComponentList rootComponents)
+        internal void Initialize(IServiceProvider services, RootComponentList rootComponents, IFileProvider fileprovider)
         {
             Services = services;
 
@@ -36,7 +36,7 @@ namespace Photino.Blazor
             // unclear there's any other use case. We can add more options later if so.
             string hostPage = "index.html";
             var contentRootDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "wwwroot");
-            var fileProvider = new PhysicalFileProvider(contentRootDir);
+            var fileProvider = fileprovider ?? new PhysicalFileProvider(contentRootDir);
 
             var dispatcher = new PhotinoDispatcher(MainWindow);
             var jsComponents = new JSComponentConfigurationStore();

--- a/Photino.Blazor/PhotinoBlazorAppBuilder.cs
+++ b/Photino.Blazor/PhotinoBlazorAppBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.FileProviders;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -39,14 +40,14 @@ namespace Photino.Blazor
         public IServiceCollection Services { get; }
 
 
-        public PhotinoBlazorApp Build(Action<IServiceProvider> serviceProviderOptions = null)
+        public PhotinoBlazorApp Build(Action<IServiceProvider> serviceProviderOptions = null, IFileProvider fileprovider = null)
         {
             var sp = Services.BuildServiceProvider();
             var app = sp.GetRequiredService<PhotinoBlazorApp>();
 
             serviceProviderOptions?.Invoke(sp);
 
-            app.Initialize(sp, RootComponents);
+            app.Initialize(sp, RootComponents, fileprovider);
             return app;
         }
     }


### PR DESCRIPTION
With this changes, a developer can provide his own FileProvider instance to be used instead of PhysicalFileProvider.

In my use-case, a custom combined provider is used to provide files from embedded resources and fallback to physical file if not found.