### PR TITLE
Added configuration manager to PhotinoBlazorAppBuilder

### DIFF
--- a/Photino.Blazor/PhotinoBlazorAppBuilder.cs
+++ b/Photino.Blazor/PhotinoBlazorAppBuilder.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
 
 namespace Photino.Blazor
 {
@@ -12,6 +13,7 @@ namespace Photino.Blazor
         {
             RootComponents = new RootComponentList();
             Services = new ServiceCollection();
+            ConfigurationManager = new ConfigurationManager();
         }
 
         public static PhotinoBlazorAppBuilder CreateDefault(string[] args = default)
@@ -32,6 +34,8 @@ namespace Photino.Blazor
         public RootComponentList RootComponents { get; }
 
         public IServiceCollection Services { get; }
+
+        public ConfigurationManager ConfigurationManager { get; }
 
         public PhotinoBlazorApp Build(Action<IServiceProvider> serviceProviderOptions = null)
         {

--- a/Photino.Blazor/PhotinoBlazorAppBuilder.cs
+++ b/Photino.Blazor/PhotinoBlazorAppBuilder.cs
@@ -23,7 +23,9 @@ namespace Photino.Blazor
             // var jsRuntime = DefaultWebAssemblyJSRuntime.Instance;
             var builder = new PhotinoBlazorAppBuilder();
             builder.Services.AddBlazorDesktop();
-            builder.Services.AddSingleton<IConfiguration>(builder.ConfigurationManager);
+
+            // register configuration as factory to make it dispose with the service provider
+            builder.Services.AddSingleton<IConfiguration>(_ => builder.ConfigurationManager);
 
             // Right now we don't have conventions or behaviors that are specific to this method
             // however, making this the default for the template allows us to add things like that

--- a/Photino.Blazor/PhotinoBlazorAppBuilder.cs
+++ b/Photino.Blazor/PhotinoBlazorAppBuilder.cs
@@ -23,6 +23,7 @@ namespace Photino.Blazor
             // var jsRuntime = DefaultWebAssemblyJSRuntime.Instance;
             var builder = new PhotinoBlazorAppBuilder();
             builder.Services.AddBlazorDesktop();
+            builder.Services.AddSingleton<IConfiguration>(builder.ConfigurationManager);
 
             // Right now we don't have conventions or behaviors that are specific to this method
             // however, making this the default for the template allows us to add things like that

--- a/Photino.Blazor/PhotinoBlazorAppBuilder.cs
+++ b/Photino.Blazor/PhotinoBlazorAppBuilder.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace Photino.Blazor
 {
@@ -14,6 +15,7 @@ namespace Photino.Blazor
             RootComponents = new RootComponentList();
             Services = new ServiceCollection();
             ConfigurationManager = new ConfigurationManager();
+            Logging = new LoggingBuilder(Services);
         }
 
         public static PhotinoBlazorAppBuilder CreateDefault(string[] args = default)
@@ -39,6 +41,8 @@ namespace Photino.Blazor
         public IServiceCollection Services { get; }
 
         public ConfigurationManager ConfigurationManager { get; }
+
+        public ILoggingBuilder Logging { get; }
 
         public PhotinoBlazorApp Build(Action<IServiceProvider> serviceProviderOptions = null)
         {
@@ -73,5 +77,15 @@ namespace Photino.Blazor
         {
             return components.GetEnumerator();
         }
+    }
+
+    class LoggingBuilder : ILoggingBuilder
+    {
+        public LoggingBuilder(IServiceCollection services)
+        {
+            Services = services;
+        }
+
+        public IServiceCollection Services { get; }
     }
 }


### PR DESCRIPTION
I was very surprised PhotinoBlazorAppBuilder didn't have a ConfigurationManager considering many other builders have one.
E.g.:

```csharp
public sealed class MauiAppBuilder
{
    /// <summary>
    /// A collection of configuration providers for the application to compose. This is useful for adding new configuration sources and providers.
    /// </summary>
    public ConfigurationManager Configuration { get; }
}

public sealed class WebApplicationBuilder
{
    /// <summary>
    /// Initial configuration sources to be added to the <see cref="HostApplicationBuilder.Configuration"/>. These sources can influence
    /// the <see cref="HostApplicationBuilder.Environment"/> through the use of <see cref="HostDefaults"/> keys. Disposing the built
    /// <see cref="IHost"/> disposes the <see cref="ConfigurationManager"/>.
    /// </summary>
    public ConfigurationManager? Configuration { get; set; }
}

public sealed class WebAssemblyHostBuilder // this one is a special one but it has one too
{
    /// <summary>
    /// Gets an <see cref="WebAssemblyHostConfiguration"/> that can be used to customize the application's
    /// configuration sources and read configuration attributes.
    /// </summary>
    public WebAssemblyHostConfiguration Configuration { get; }
}
```

This also will help a little to implement new IHostApplicationBuilder interface introduced in .Net 8 (https://github.com/dotnet/runtime/pull/86974)