### PR TITLE
feat: allow for custom urls or html files on PhotinoBlazorApp.Run()

### DIFF
--- a/Photino.Blazor/PhotinoBlazorApp.cs
+++ b/Photino.Blazor/PhotinoBlazorApp.cs
@@ -44,9 +44,13 @@ namespace Photino.Blazor
 
         public PhotinoWebViewManager WindowManager { get; private set; }
 
-        public void Run()
+        /// <summary>
+        /// Runs the Blazor application.
+        /// </summary>
+        /// <param name="url">URL to application's main HTML file. This defaults to index.html.</param>
+        public void Run(string url = "/")
         {
-            WindowManager.Navigate("/");
+            WindowManager.Navigate(url);
             MainWindow.WaitForClose();
         }
 


### PR DESCRIPTION
## Description
Solves issue https://github.com/tryphotino/photino.Blazor/issues/62.

Adds an optional URL parameter to `PhotinoBlazorApp.Run()` which allows for different HTML files to be used. The previous behavior was hardcoded to use the application's provided `index.html` file, which has been retained as the default value for the new url parameter.

This change is useful for multi-window applications that want to target different HTML files for different layouts or purposes on a per-window basis, but I'm sure there are other use-cases that this enables as well.