### PR TITLE
Override IFileProvider for static file assets

### DIFF
--- a/Photino.Blazor/PhotinoBlazorAppBuilder.cs
+++ b/Photino.Blazor/PhotinoBlazorAppBuilder.cs
@@ -7,80 +7,80 @@ using System.Collections.Generic;
 
 namespace Photino.Blazor
 {
-	public class PhotinoBlazorAppBuilder
-	{
-		internal PhotinoBlazorAppBuilder()
-		{
-			RootComponents = new RootComponentList();
-			Services = new ServiceCollection();
-		}
+    public class PhotinoBlazorAppBuilder
+    {
+        internal PhotinoBlazorAppBuilder()
+        {
+            RootComponents = new RootComponentList();
+            Services = new ServiceCollection();
+        }
 
-		public static PhotinoBlazorAppBuilder CreateDefault(string[] args = default)
-		{
-			return CreateDefault(null, args);
-		}
+        public static PhotinoBlazorAppBuilder CreateDefault(string[] args = default)
+        {
+            return CreateDefault(null, args);
+        }
 
-		public static PhotinoBlazorAppBuilder CreateDefault(IFileProvider fileProvider, string[] args = default)
-		{
-			// We don't use the args for anything right now, but we want to accept them
-			// here so that it shows up this way in the project templates.
-			// var jsRuntime = DefaultWebAssemblyJSRuntime.Instance;
-			var builder = new PhotinoBlazorAppBuilder();
-			builder.Services.AddBlazorDesktop(fileProvider);
+        public static PhotinoBlazorAppBuilder CreateDefault(IFileProvider fileProvider, string[] args = default)
+        {
+            // We don't use the args for anything right now, but we want to accept them
+            // here so that it shows up this way in the project templates.
+            // var jsRuntime = DefaultWebAssemblyJSRuntime.Instance;
+            var builder = new PhotinoBlazorAppBuilder();
+            builder.Services.AddBlazorDesktop(fileProvider);
 
-			// Right now we don't have conventions or behaviors that are specific to this method
-			// however, making this the default for the template allows us to add things like that
-			// in the future, while giving `new BlazorDesktopHostBuilder` as an opt-out of opinionated
-			// settings.
-			return builder;
-		}
+            // Right now we don't have conventions or behaviors that are specific to this method
+            // however, making this the default for the template allows us to add things like that
+            // in the future, while giving `new BlazorDesktopHostBuilder` as an opt-out of opinionated
+            // settings.
+            return builder;
+        }
 
-		public RootComponentList RootComponents { get; }
+        public RootComponentList RootComponents { get; }
 
-		public IServiceCollection Services { get; }
+        public IServiceCollection Services { get; }
 
-		public PhotinoBlazorApp Build(Action<IServiceProvider> serviceProviderOptions = null)
-		{
-			// register root components with DI container
-			// Services.AddSingleton(RootComponents);
+        public PhotinoBlazorApp Build(Action<IServiceProvider> serviceProviderOptions = null)
+        {
+            // register root components with DI container
+            // Services.AddSingleton(RootComponents);
 
-			var sp = Services.BuildServiceProvider();
-			var app = sp.GetRequiredService<PhotinoBlazorApp>();
+            var sp = Services.BuildServiceProvider();
+            var app = sp.GetRequiredService<PhotinoBlazorApp>();
 
-			serviceProviderOptions?.Invoke(sp);
+            serviceProviderOptions?.Invoke(sp);
 
-			app.Initialize(sp, RootComponents);
-			return app;
-		}
-	}
+            app.Initialize(sp, RootComponents);
+            return app;
+        }
+    }
 
-	public class RootComponentList : IEnumerable<(Type, string)>
-	{
-		private readonly List<(Type componentType, string domElementSelector)> components = new List<(Type componentType, string domElementSelector)>();
+    public class RootComponentList : IEnumerable<(Type, string)>
+    {
+        private readonly List<(Type componentType, string domElementSelector)> components = new List<(Type componentType, string domElementSelector)>();
 
-		public void Add<TComponent>(string selector) where TComponent : IComponent
-		{
-			components.Add((typeof(TComponent), selector));
-		}
+        public void Add<TComponent>(string selector) where TComponent : IComponent
+        {
+            components.Add((typeof(TComponent), selector));
+        }
 
-		public void Add(Type componentType, string selector)
-		{
-			if (!typeof(IComponent).IsAssignableFrom(componentType))
-			{
-				throw new ArgumentException("The component type must implement IComponent interface.");
-			}
+        public void Add(Type componentType, string selector)
+        {
+            if (!typeof(IComponent).IsAssignableFrom(componentType))
+            {
+                throw new ArgumentException("The component type must implement IComponent interface.");
+            }
 
-			components.Add((componentType, selector));
-		}
+            components.Add((componentType, selector));
+        }
 
-		public IEnumerator<(Type, string)> GetEnumerator()
-		{
-			return components.GetEnumerator();
-		}
+        public IEnumerator<(Type, string)> GetEnumerator()
+        {
+            return components.GetEnumerator();
+        }
 
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			return components.GetEnumerator();
-		}
-	}
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return components.GetEnumerator();
+        }
+    }
 }

--- a/Photino.Blazor/PhotinoBlazorAppBuilder.cs
+++ b/Photino.Blazor/PhotinoBlazorAppBuilder.cs
@@ -1,80 +1,86 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 
 namespace Photino.Blazor
 {
-    public class PhotinoBlazorAppBuilder
-    {
-        internal PhotinoBlazorAppBuilder()
-        {
-            RootComponents = new RootComponentList();
-            Services = new ServiceCollection();
-        }
+	public class PhotinoBlazorAppBuilder
+	{
+		internal PhotinoBlazorAppBuilder()
+		{
+			RootComponents = new RootComponentList();
+			Services = new ServiceCollection();
+		}
 
-        public static PhotinoBlazorAppBuilder CreateDefault(string[] args = default)
-        {
-            // We don't use the args for anything right now, but we want to accept them
-            // here so that it shows up this way in the project templates.
-            // var jsRuntime = DefaultWebAssemblyJSRuntime.Instance;
-            var builder = new PhotinoBlazorAppBuilder();
-            builder.Services.AddBlazorDesktop();
+		public static PhotinoBlazorAppBuilder CreateDefault(string[] args = default)
+		{
+			return CreateDefault(null, args);
+		}
 
-            // Right now we don't have conventions or behaviors that are specific to this method
-            // however, making this the default for the template allows us to add things like that
-            // in the future, while giving `new BlazorDesktopHostBuilder` as an opt-out of opinionated
-            // settings.
-            return builder;
-        }
+		public static PhotinoBlazorAppBuilder CreateDefault(IFileProvider fileProvider, string[] args = default)
+		{
+			// We don't use the args for anything right now, but we want to accept them
+			// here so that it shows up this way in the project templates.
+			// var jsRuntime = DefaultWebAssemblyJSRuntime.Instance;
+			var builder = new PhotinoBlazorAppBuilder();
+			builder.Services.AddBlazorDesktop(fileProvider);
 
-        public RootComponentList RootComponents { get; }
+			// Right now we don't have conventions or behaviors that are specific to this method
+			// however, making this the default for the template allows us to add things like that
+			// in the future, while giving `new BlazorDesktopHostBuilder` as an opt-out of opinionated
+			// settings.
+			return builder;
+		}
 
-        public IServiceCollection Services { get; }
+		public RootComponentList RootComponents { get; }
 
-        public PhotinoBlazorApp Build(Action<IServiceProvider> serviceProviderOptions = null)
-        {
-            // register root components with DI container
-            // Services.AddSingleton(RootComponents);
+		public IServiceCollection Services { get; }
 
-            var sp = Services.BuildServiceProvider();
-            var app = sp.GetRequiredService<PhotinoBlazorApp>();
+		public PhotinoBlazorApp Build(Action<IServiceProvider> serviceProviderOptions = null)
+		{
+			// register root components with DI container
+			// Services.AddSingleton(RootComponents);
 
-            serviceProviderOptions?.Invoke(sp);
+			var sp = Services.BuildServiceProvider();
+			var app = sp.GetRequiredService<PhotinoBlazorApp>();
 
-            app.Initialize(sp, RootComponents);
-            return app;
-        }
-    }
+			serviceProviderOptions?.Invoke(sp);
 
-    public class RootComponentList : IEnumerable<(Type, string)>
-    {
-        private readonly List<(Type componentType, string domElementSelector)> components = new List<(Type componentType, string domElementSelector)>();
+			app.Initialize(sp, RootComponents);
+			return app;
+		}
+	}
 
-        public void Add<TComponent>(string selector) where TComponent : IComponent
-        {
-            components.Add((typeof(TComponent), selector));
-        }
+	public class RootComponentList : IEnumerable<(Type, string)>
+	{
+		private readonly List<(Type componentType, string domElementSelector)> components = new List<(Type componentType, string domElementSelector)>();
 
-        public void Add(Type componentType, string selector)
-        {
-            if (!typeof(IComponent).IsAssignableFrom(componentType))
-            {
-                throw new ArgumentException("The component type must implement IComponent interface.");
-            }
+		public void Add<TComponent>(string selector) where TComponent : IComponent
+		{
+			components.Add((typeof(TComponent), selector));
+		}
 
-            components.Add((componentType, selector));
-        }
+		public void Add(Type componentType, string selector)
+		{
+			if (!typeof(IComponent).IsAssignableFrom(componentType))
+			{
+				throw new ArgumentException("The component type must implement IComponent interface.");
+			}
 
-        public IEnumerator<(Type, string)> GetEnumerator()
-        {
-            return components.GetEnumerator();
-        }
+			components.Add((componentType, selector));
+		}
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return components.GetEnumerator();
-        }
-    }
+		public IEnumerator<(Type, string)> GetEnumerator()
+		{
+			return components.GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return components.GetEnumerator();
+		}
+	}
 }

--- a/Photino.Blazor/ServiceCollectionExtensions.cs
+++ b/Photino.Blazor/ServiceCollectionExtensions.cs
@@ -9,44 +9,51 @@ using PhotinoNET;
 
 namespace Photino.Blazor
 {
-    public static class ServiceCollectionExtensions
-    {
-        public static IServiceCollection AddBlazorDesktop(this IServiceCollection services)
-        {
-            services
-                .AddOptions<PhotinoBlazorAppConfiguration>()
-                .Configure(opts =>
-                {
-                    opts.AppBaseUri = new Uri(PhotinoWebViewManager.AppBaseUri);
-                    opts.HostPage = "index.html";
-                });
+	public static class ServiceCollectionExtensions
+	{
+		public static IServiceCollection AddBlazorDesktop(this IServiceCollection services, IFileProvider fileProvider = null)
+		{
+			services
+				.AddOptions<PhotinoBlazorAppConfiguration>()
+				.Configure(opts =>
+				{
+					opts.AppBaseUri = new Uri(PhotinoWebViewManager.AppBaseUri);
+					opts.HostPage = "index.html";
+				});
 
-            return services
-                .AddScoped(sp =>
-                {
-                    var handler = sp.GetService<PhotinoHttpHandler>();
-                    return new HttpClient(handler) { BaseAddress = new Uri(PhotinoWebViewManager.AppBaseUri) };
-                })
-                .AddSingleton(sp =>
-                {
-                    var manager = sp.GetService<PhotinoWebViewManager>();
-                    var store = sp.GetService<JSComponentConfigurationStore>();
+			return services
+				.AddScoped(sp =>
+				{
+					var handler = sp.GetService<PhotinoHttpHandler>();
+					return new HttpClient(handler) { BaseAddress = new Uri(PhotinoWebViewManager.AppBaseUri) };
+				})
+				.AddSingleton(sp =>
+				{
+					var manager = sp.GetService<PhotinoWebViewManager>();
+					var store = sp.GetService<JSComponentConfigurationStore>();
 
-                    return new BlazorWindowRootComponents(manager, store);
-                })
-                .AddSingleton<Dispatcher, PhotinoDispatcher>()
-                .AddSingleton<IFileProvider>(_ =>
-                {
-                    var root = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "wwwroot");
-                    return new PhysicalFileProvider(root);
-                })
-                .AddSingleton<JSComponentConfigurationStore>()
-                .AddSingleton<PhotinoBlazorApp>()
-                .AddSingleton<PhotinoHttpHandler>()
-                .AddSingleton<PhotinoSynchronizationContext>()
-                .AddSingleton<PhotinoWebViewManager>()
-                .AddSingleton(new PhotinoWindow())
-                .AddBlazorWebView();
-        }
-    }
+					return new BlazorWindowRootComponents(manager, store);
+				})
+				.AddSingleton<Dispatcher, PhotinoDispatcher>()
+				.AddSingleton<IFileProvider>(_ =>
+				{
+					if (fileProvider is null)
+					{
+						var root = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "wwwroot");
+						return new PhysicalFileProvider(root);
+					}
+					else
+					{
+						return fileProvider;
+					}
+				})
+				.AddSingleton<JSComponentConfigurationStore>()
+				.AddSingleton<PhotinoBlazorApp>()
+				.AddSingleton<PhotinoHttpHandler>()
+				.AddSingleton<PhotinoSynchronizationContext>()
+				.AddSingleton<PhotinoWebViewManager>()
+				.AddSingleton(new PhotinoWindow())
+				.AddBlazorWebView();
+		}
+	}
 }

--- a/Photino.Blazor/ServiceCollectionExtensions.cs
+++ b/Photino.Blazor/ServiceCollectionExtensions.cs
@@ -9,51 +9,51 @@ using PhotinoNET;
 
 namespace Photino.Blazor
 {
-	public static class ServiceCollectionExtensions
-	{
-		public static IServiceCollection AddBlazorDesktop(this IServiceCollection services, IFileProvider fileProvider = null)
-		{
-			services
-				.AddOptions<PhotinoBlazorAppConfiguration>()
-				.Configure(opts =>
-				{
-					opts.AppBaseUri = new Uri(PhotinoWebViewManager.AppBaseUri);
-					opts.HostPage = "index.html";
-				});
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddBlazorDesktop(this IServiceCollection services, IFileProvider fileProvider = null)
+        {
+            services
+                .AddOptions<PhotinoBlazorAppConfiguration>()
+                .Configure(opts =>
+                {
+                    opts.AppBaseUri = new Uri(PhotinoWebViewManager.AppBaseUri);
+                    opts.HostPage = "index.html";
+                });
 
-			return services
-				.AddScoped(sp =>
-				{
-					var handler = sp.GetService<PhotinoHttpHandler>();
-					return new HttpClient(handler) { BaseAddress = new Uri(PhotinoWebViewManager.AppBaseUri) };
-				})
-				.AddSingleton(sp =>
-				{
-					var manager = sp.GetService<PhotinoWebViewManager>();
-					var store = sp.GetService<JSComponentConfigurationStore>();
+            return services
+                .AddScoped(sp =>
+                {
+                    var handler = sp.GetService<PhotinoHttpHandler>();
+                    return new HttpClient(handler) { BaseAddress = new Uri(PhotinoWebViewManager.AppBaseUri) };
+                })
+                .AddSingleton(sp =>
+                {
+                    var manager = sp.GetService<PhotinoWebViewManager>();
+                    var store = sp.GetService<JSComponentConfigurationStore>();
 
-					return new BlazorWindowRootComponents(manager, store);
-				})
-				.AddSingleton<Dispatcher, PhotinoDispatcher>()
-				.AddSingleton<IFileProvider>(_ =>
-				{
-					if (fileProvider is null)
-					{
-						var root = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "wwwroot");
-						return new PhysicalFileProvider(root);
-					}
-					else
-					{
-						return fileProvider;
-					}
-				})
-				.AddSingleton<JSComponentConfigurationStore>()
-				.AddSingleton<PhotinoBlazorApp>()
-				.AddSingleton<PhotinoHttpHandler>()
-				.AddSingleton<PhotinoSynchronizationContext>()
-				.AddSingleton<PhotinoWebViewManager>()
-				.AddSingleton(new PhotinoWindow())
-				.AddBlazorWebView();
-		}
-	}
+                    return new BlazorWindowRootComponents(manager, store);
+                })
+                .AddSingleton<Dispatcher, PhotinoDispatcher>()
+                .AddSingleton<IFileProvider>(_ =>
+                {
+                    if (fileProvider is null)
+                    {
+                        var root = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "wwwroot");
+                        return new PhysicalFileProvider(root);
+                    }
+                    else
+                    {
+                        return fileProvider;
+                    }
+                })
+                .AddSingleton<JSComponentConfigurationStore>()
+                .AddSingleton<PhotinoBlazorApp>()
+                .AddSingleton<PhotinoHttpHandler>()
+                .AddSingleton<PhotinoSynchronizationContext>()
+                .AddSingleton<PhotinoWebViewManager>()
+                .AddSingleton(new PhotinoWindow())
+                .AddBlazorWebView();
+        }
+    }
 }


### PR DESCRIPTION
Implements https://github.com/tryphotino/photino.Blazor/issues/115 and allows to set custom IFileProvider instead of the default one defined in AddBlazorDesktop().

Allows use of eg. ManifestEmbeddedFileProvider or PhysicalFileProvider (which points to different wwwroot location as default provider):
```csharp
// use ManifestEmbeddedFileProvider for static web assets
var fileProvider = new ManifestEmbeddedFileProvider(Assembly.GetAssembly(type: typeof(Program)), "wwwroot");
var appBuilder = PhotinoBlazorAppBuilder.CreateDefault(fileProvider, args);

appBuilder.Services.AddLogging();

// register root component and selector
appBuilder.RootComponents.Add<App>("app");

var app = appBuilder.Build();
```