### PR TITLE
Fix handling of app:// URLs containing a #fragment

### DIFF
--- a/Photino.Blazor/PhotinoWebViewManager.cs
+++ b/Photino.Blazor/PhotinoWebViewManager.cs
@@ -68,6 +68,11 @@ namespace Photino.Blazor
 
             //Remove parameters before attempting to retrieve the file. For example: http://localhost/_content/Blazorise/button.js?v=1.0.7.0
             if (url.Contains('?')) url = url.Substring(0, url.IndexOf('?'));
+            int fragmentPos = url.IndexOf('#');
+            if (fragmentPos != -1)
+            {
+                url = url.Substring(0, fragmentPos);
+            }
 
             if (url.StartsWith(AppBaseUri, StringComparison.Ordinal)
                 && TryGetResponseContent(url, !hasFileExtension, out var statusCode, out var statusMessage,


### PR DESCRIPTION
Currently, `app://` URLs which contain a fragment, e.g. `app://localhost/example.html#fragment`, return a “there is no content at \<URL including fragment>” even though the actual file exists, because it is looking for the file `example.html#fragment`.

This fixes it by simply removing the fragment from the requested filename, because the fragment anyway has to be handled by the browser and not the server.