### PR TITLE
Add .NET 10 support. Update version to 5.0.

### DIFF
--- a/Photino.Blazor/Photino.Blazor.csproj
+++ b/Photino.Blazor/Photino.Blazor.csproj
@@ -3,15 +3,15 @@
 	<PropertyGroup>
 		<Authors>TryPhotino</Authors>
 		<Company>TryPhotino</Company>
-		<Description>.NET 8/9 app that opens native OS windows hosting Blazor UI on Windows, Mac, and Linux</Description>
+		<Description>.NET 8/9/10 app that opens native OS windows hosting Blazor UI on Windows, Mac, and Linux</Description>
 		<GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);SetPackageVersion</GenerateNuspecDependsOn>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-		<PackageDescription>.NET 8/9 app that opens native OS windows hosting Blazor UI on Windows, Mac, and Linux</PackageDescription>
+		<PackageDescription>.NET 8/9/10 app that opens native OS windows hosting Blazor UI on Windows, Mac, and Linux</PackageDescription>
 		<PackageId>Photino.Blazor</PackageId>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/tryphotino/photino.Blazor</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/tryphotino/photino.Blazor</RepositoryUrl>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<Title>Photino.blazor</Title>
 		<PackageIcon>photino.png</PackageIcon>
 		<OutputType>Library</OutputType>
@@ -35,13 +35,18 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="8.0.12" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="8.0.29" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="9.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="9.0.18" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.18" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/HelloWorld/HelloWorld.csproj
+++ b/Samples/HelloWorld/HelloWorld.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ApplicationIcon>favicon.ico</ApplicationIcon>
 	</PropertyGroup>
 

--- a/Samples/Photino.Blazor.MultiWindowSample/Photino.Blazor.MultiWindowSample.csproj
+++ b/Samples/Photino.Blazor.MultiWindowSample/Photino.Blazor.MultiWindowSample.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ApplicationIcon>favicon.ico</ApplicationIcon>
 	</PropertyGroup>
 

--- a/Samples/Photino.Blazor.NativeAOT/Photino.Blazor.NativeAOT.csproj
+++ b/Samples/Photino.Blazor.NativeAOT/Photino.Blazor.NativeAOT.csproj
@@ -2,7 +2,7 @@
 	
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ApplicationIcon>favicon.ico</ApplicationIcon>
 		<IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
 		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>

--- a/Samples/Photino.Blazor.Sample/Photino.Blazor.Sample.csproj
+++ b/Samples/Photino.Blazor.Sample/Photino.Blazor.Sample.csproj
@@ -2,7 +2,7 @@
 	
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ApplicationIcon>favicon.ico</ApplicationIcon>
 	</PropertyGroup>
 

--- a/azure-pipelines-photino.blazor-dev.yml
+++ b/azure-pipelines-photino.blazor-dev.yml
@@ -18,10 +18,10 @@ jobs:
 
       steps:
           - task: UseDotNet@2
-            displayName: "Use .NET 9 sdk"
+            displayName: "Use .NET 10 sdk"
             inputs:
                 packageType: sdk
-                version: "9.0.x"
+                version: "10.0.x"
                 installationPath: $(Agent.ToolsDirectory)/dotnet
 
           - task: CmdLine@2

--- a/azure-pipelines-photino.blazor-prod.yml
+++ b/azure-pipelines-photino.blazor-prod.yml
@@ -5,7 +5,7 @@ trigger:
     - manual
 
 variables:
-    major: 4
+    major: 5
     minor: 0
     patch: $[counter(variables['minor'], 0)] #this will reset when we bump minor
     buildConfiguration: "Release"
@@ -18,10 +18,10 @@ jobs:
 
       steps:
           - task: UseDotNet@2
-            displayName: "Use .NET 9 sdk"
+            displayName: "Use .NET 10 sdk"
             inputs:
                 packageType: sdk
-                version: "9.0.x"
+                version: "10.0.x"
                 installationPath: $(Agent.ToolsDirectory)/dotnet
 
           #Build and Create NuGet package


### PR DESCRIPTION
Add net10.0 to the library's target frameworks alongside net8.0 and net9.0, with a matching 10.0.10 package reference group. Bump the existing WebView references to the latest servicing patches (8.0.29, 9.0.18); Microsoft.Extensions.Logging.Console stays at 8.0.1 for net8.0 because that is the newest version published on the 8.x line.

Move the four samples to net10.0 and update both Azure pipelines to the 10.0.x SDK. Bump the prod pipeline major version to 5.

Verified: solution builds clean against all three targets, the packed nupkg carries net8.0/net9.0/net10.0 lib assets, and the HelloWorld sample runs on net10.0 on osx-arm64 (native dylib loads, window opens, Blazor render batch reaches the WebView).